### PR TITLE
refactor: spec_helper.rbからActiveSupport::Dependencies.autoload_pathにパスを追加する処理を削除した。

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,8 @@ Bundler.require :default, :development
 
 # If you're using all parts of Rails:
 Combustion.initialize! :active_record, :action_controller, :action_view
-require 'active_support'
-ActiveSupport::Dependencies.autoload_paths << '../lib'
 
 require 'ransack'
-
 require 'rspec/rails'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Railsガイドに改変してはいけないと書いてあった。

https://railsguides.jp/autoloading_and_reloading_constants.html